### PR TITLE
cl_specdm_hud.lua removed from addcsluafile

### DIFF
--- a/lua/sv_spectator_deathmatch.lua
+++ b/lua/sv_spectator_deathmatch.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile("cl_spectator_deathmatch.lua")
 AddCSLuaFile("sh_spectator_deathmatch.lua")
 AddCSLuaFile("specdm_config.lua")
-AddCSLuaFile("cl_specdm_hud.lua")
 AddCSLuaFile("vgui/spec_dm_loadout.lua")
 AddCSLuaFile("cl_stats.lua")
 AddCSLuaFile("specdm_von.lua")


### PR DESCRIPTION
Not required because it doesn't exists and creates therefore an error in the console. (It was used in the version of Tommy228.)