### PR TITLE
replaced AccessorFuncDT() and fixed health translation

### DIFF
--- a/lua/terrortown/gamemode/shared/hud_elements/ttt_dm_playerinfo/pure_skin_dm_playerinfo.lua
+++ b/lua/terrortown/gamemode/shared/hud_elements/ttt_dm_playerinfo/pure_skin_dm_playerinfo.lua
@@ -140,7 +140,7 @@ if CLIENT then
             local spc = 7 * self.scale -- space between bars
             -- health bar
             local health = math.max(0, client:Health())
-            self:DrawBar(nx, ty, bw, bh, Color(234, 41, 41), health / client:GetMaxHealth(), self.scale, string.upper(LANG.TryTranslation("hud_health")) .. ": " .. health)
+            self:DrawBar(nx, ty, bw, bh, Color(234, 41, 41), health / client:GetMaxHealth(), self.scale, "HEALTH" .. ": " .. health)
             -- ammo bar
             ty = ty + bh + spc
 

--- a/lua/weapons/weapon_ghost_base.lua
+++ b/lua/weapons/weapon_ghost_base.lua
@@ -113,7 +113,7 @@ SWEP.IsDropped = false
 SWEP.DeploySpeed = 1.4
 SWEP.PrimaryAnim = ACT_VM_PRIMARYATTACK_SILENCED
 SWEP.ReloadAnim = ACT_VM_RELOAD
-AccessorFuncDT(SWEP, "ironsights", "Ironsights")
+AccessorFunc(SWEP, "ironsights", "Ironsights")
 SWEP.fingerprints = {}
 -- local sparkle = CLIENT and CreateConVar("ttt_crazy_sparks", "0", FCVAR_ARCHIVE)
 local crosshair_size = CreateConVar("ttt_crosshair_size", "1.0", FCVAR_ARCHIVE)


### PR DESCRIPTION
AccessorFuncDT() is deprecated and showed a warning in the console.
This was fixed with AccessorFunc().

The translation for health was removed in TTT2 and replaced by an icon (icons were also added for ammunition).
This missing translation was also "fixed" (Hardcoded because I think icons and similar new stuff from TTT2 is not needed for SpecDM.).

Tested and it worked fine. 

Edit: 
Don't merge yet, I found a better fix for the missing translation of health.
Edit 2:
Will do new pull request.