### PR TITLE
replaced AccessorFuncDT() and fixed health translation

### DIFF
--- a/lua/terrortown/gamemode/shared/hud_elements/ttt_dm_playerinfo/pure_skin_dm_playerinfo.lua
+++ b/lua/terrortown/gamemode/shared/hud_elements/ttt_dm_playerinfo/pure_skin_dm_playerinfo.lua
@@ -140,7 +140,7 @@ if CLIENT then
             local spc = 7 * self.scale -- space between bars
             -- health bar
             local health = math.max(0, client:Health())
-            self:DrawBar(nx, ty, bw, bh, Color(234, 41, 41), health / client:GetMaxHealth(), self.scale, string.upper(LANG.TryTranslation("hud_health")) .. ": " .. health)
+            self:DrawBar(nx, ty, bw, bh, Color(234, 41, 41), health / client:GetMaxHealth(), self.scale, string.upper(LANG.TryTranslation("ttt2_spectator_deathmatch_health")) .. ": " .. health)
             -- ammo bar
             ty = ty + bh + spc
 

--- a/lua/terrortown/lang/de/spectator_deathmatch.lua
+++ b/lua/terrortown/lang/de/spectator_deathmatch.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("de")
 -- HUD
 L["ttt2_spectator_deathmatch_name"] = "Geist"
+L["ttt2_spectator_deathmatch_health"] = "Leben"
 -- VGUI
 L["ttt2_spectator_deathmatch_text_1"] = "Zufällige Waffe"
 L["ttt2_spectator_deathmatch_text_2"] = "Speichern"

--- a/lua/terrortown/lang/en/spectator_deathmatch.lua
+++ b/lua/terrortown/lang/en/spectator_deathmatch.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("en")
 -- HUD
 L["ttt2_spectator_deathmatch_name"] = "Ghost"
+L["ttt2_spectator_deathmatch_health"] = "Health"
 -- VGUI
 L["ttt2_spectator_deathmatch_text_1"] = "Random weapon"
 L["ttt2_spectator_deathmatch_text_2"] = "Save"

--- a/lua/terrortown/lang/zh_hans/spectator_deathmatch.lua
+++ b/lua/terrortown/lang/zh_hans/spectator_deathmatch.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("zh_hans")
 -- HUD
 L["ttt2_spectator_deathmatch_name"] = "幽灵"
+L["ttt2_spectator_deathmatch_health"] = "生命值"
 -- VGUI
 L["ttt2_spectator_deathmatch_text_1"] = "随机武器"
 L["ttt2_spectator_deathmatch_text_2"] = "保存"

--- a/lua/weapons/weapon_ghost_base.lua
+++ b/lua/weapons/weapon_ghost_base.lua
@@ -113,7 +113,7 @@ SWEP.IsDropped = false
 SWEP.DeploySpeed = 1.4
 SWEP.PrimaryAnim = ACT_VM_PRIMARYATTACK_SILENCED
 SWEP.ReloadAnim = ACT_VM_RELOAD
-AccessorFuncDT(SWEP, "ironsights", "Ironsights")
+AccessorFunc(SWEP, "ironsights", "Ironsights")
 SWEP.fingerprints = {}
 -- local sparkle = CLIENT and CreateConVar("ttt_crazy_sparks", "0", FCVAR_ARCHIVE)
 local crosshair_size = CreateConVar("ttt_crosshair_size", "1.0", FCVAR_ARCHIVE)


### PR DESCRIPTION
AccessorFuncDT() is deprecated and showed a warning in the console.
This was fixed with AccessorFunc().

The translation for health was removed in TTT2 and replaced by an icon (icons were also added for ammunition).
The missing translations were fixed by adding them to the lang files of SpecDM.

Tested and it worked fine.

Maybe also a new release because some stuff has changed since the last release?