### PR TITLE
fixed IsGhost nil value error

### DIFF
--- a/lua/cl_spectator_deathmatch.lua
+++ b/lua/cl_spectator_deathmatch.lua
@@ -419,6 +419,7 @@ hook.Add("Initialize", "Initialize_Ghost", function()
     local oldTraceLine = util.TraceLine
 
     function util.TraceLine(tbl)
+        if not IsValid(LocalPlayer()) then return end
         local plyghost = LocalPlayer():IsGhost()
         if not istable(tbl) or (plyghost and showalive:GetBool()) then return oldTraceLine(tbl) end
         local filt = tbl.filter


### PR DESCRIPTION
Fixed the following error which happened for one player:
```
[[TTT2] Spectator Deathmatch [FEATURE]] lua/cl_spectator_deathmatch.lua:422: attempt to call method 'IsGhost' (a nil value)
  1. TraceLine - lua/cl_spectator_deathmatch.lua:422
   2. ExplosionPos - lua/zippy_explosion_enhancer/sh_explosion.lua:41
    3. ZExplosionEnhancer_Explosion - lua/zippy_explosion_enhancer/sh_explosion.lua:70
     4. func - lua/zippy_explosion_enhancer/sh_replacer.lua:74
      5. unknown - lua/includes/extensions/net.lua:38
```
This should make the code more robust.